### PR TITLE
Implemented Makefile build system

### DIFF
--- a/LuaFortran/Makefile.inc
+++ b/LuaFortran/Makefile.inc
@@ -1,0 +1,34 @@
+LuaF_DIR = $(TOP_DIR)/LuaFortran
+
+# Append the LuaFortran directory
+VPATH := $(VPATH):$(LuaF_DIR)
+
+# Objects in this folder
+LuaF_OBJECTS = dump_lua_fif_module.o \
+	     flu_binding.o \
+	     flu_kinds_module.o \
+	     lua_fif.o \
+	     lua_parameters.o
+LuaF_SOURCES := $(patsubst %.o, %.f90, $(LuaF_OBJECTS))
+
+# Add the C-sources
+LuaF_OBJECTS += wrap_lua_dump.o
+LuaF_SOURCES += wrap_lua_dump.c
+
+
+# Add to the global variables
+SOURCES += $(LuaF_SOURCES)
+OBJECTS += $(LuaF_OBJECTS)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:
+
+# Automatic creation of the dependencies may be achieved through:
+#   sfmakedepend --depend=obj --modext=o --file=Makefile.inc *.f90
+
+# DO NOT DELETE THIS LINE - used by make depend
+flu_binding.o: dump_lua_fif_module.o flu_kinds_module.o lua_fif.o
+flu_binding.o: lua_parameters.o
+lua_fif.o: lua_parameters.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+
+EXTERNAL_LUA_V = 5.3.4
+
+# Define VPATH
+VPATH ?= $(shell pwd)
+
+# the default target
+.PHONY: default
+default: lib
+
+# the all target
+.PHONY: all static
+all: static
+
+
+# SMEKASETTINGS (DO NOT DELETE)
+# DO NOT CHANGE CONTENT IN THIS BLOCK
+# IT MAY BE OVERWRITTEN WHEN REINSTALLING SMEKA
+#
+# This Makefile was created by smeka:
+#  github.com/zerothi/smeka
+
+# Top-directory of Makefile/source tree
+# If need set, do so ABOVE this block!
+TOP_DIR ?= .
+
+# Directory of smeka default Makefiles
+SMEKA_DIR = smeka
+
+# Include the smeka settings!
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.smeka
+
+# SMEKAENDSETTINGS (DO NOT DELETE)
+
+
+# The linker is a fortran compiler
+LINK := $(FC)
+
+# Create targets for the library
+.PHONY: lib
+lib: $(LIBRARIES)
+
+# Determine whether the user has added an external
+# Lua header file.
+ifdef LUA_DIR
+ # User-defined
+ INCLUDES += -I$(LUA_DIR)/include
+else
+ # lua-sources shipped
+ LUA_DIR = $(TOP_DIR)/external/lua-$(EXTERNAL_LUA_V)
+ INCLUDES += -I$(LUA_DIR)/src
+endif
+
+
+
+# Add the LuaFortran files
+include $(TOP_DIR)/LuaFortran/Makefile.inc
+
+# Add source files
+include $(TOP_DIR)/source/Makefile.inc
+# Add source/extdouble files
+include $(TOP_DIR)/source/extdouble/Makefile.inc
+# Add source/quadruple files
+include $(TOP_DIR)/source/quadruple/Makefile.inc
+
+
+# Ensure that all objects are required for the libraries
+$(LIBRARIES): $(OBJECTS)

--- a/Makefile.project
+++ b/Makefile.project
@@ -1,0 +1,73 @@
+_SMEKA_project = 1
+
+# Contains specific default information for this
+# project
+
+# Step this version upon new versions
+PROJECT_MAJOR = 0
+PROJECT_MINOR = 1
+PROJECT_MICRO = 0
+PROJECT_VERSION = $(PROJECT_MAJOR).$(PROJECT_MINOR).$(PROJECT_MICRO)
+
+# These are constant default
+PROJECT_NAME = aotus
+
+# Currently we only enable building aotus staticly
+STATIC ?= 1
+SHARED ?= 0
+
+AOTUS_LIB ?= aotus$(LIB_SUFFIX)
+AOTUS_LIB_STATIC ?= lib$(AOTUS_LIB).a
+AOTUS_LIB_SHARED ?= lib$(AOTUS_LIB).so
+
+ifeq ($(STATIC),1)
+  LIBRARIES += $(AOTUS_LIB_STATIC)
+endif
+ifeq ($(SHARED),1)
+  LIBRARIES += $(AOTUS_LIB_SHARED)
+  # Forcefully denote that objects should have
+  # position independent code
+  # THIS IS A SMEKA SETTING
+  PIC = 1
+endif
+
+
+# Default settings for extended precision types
+# They are default off.
+EXTDOUBLE ?= 0
+QUADRUPLE ?= 0
+
+
+# Create custom installation of modules
+.PHONY: install-mod
+.NOTPARALLEL: install-mod
+smeka-install: install-mod
+install-mod: install-version
+install-mod:
+ifneq ($(LIBRARIES),)
+# This should only pass if one wishes to install the aotus library as well
+	install -pm $(_OCT_rwrr) -t $(FMOD_DIR) *.mod
+endif
+
+
+# Although not necessary supplying a version file may be very good
+# for several reasons.
+VERSION_FILE = aotus_version.inc
+.PHONY: install-version
+.NOTPARALLEL: install-version
+install-version:
+	@echo "Creating version file: $(VERSION_FILE)"
+	@echo "#define AOTUS_MAJOR $(PROJECT_MAJOR)" > $(VERSION_FILE)
+	@echo "#define AOTUS_MINOR $(PROJECT_MINOR)" >> $(VERSION_FILE)
+	@echo "#define AOTUS_MICRO $(PROJECT_MICRO)" >> $(VERSION_FILE)
+	@echo "#define AOTUS_VERSION_STR \"$(PROJECT_MAJOR).$(PROJECT_MINOR).$(PROJECT_MICRO)\"" >> $(VERSION_FILE)
+
+
+.PHONY: clean
+clean:
+	-rm -f $(AOTUS_LIB_STATIC) $(AOTUS_LIB_SHARED) *.mod
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ which creates `bin/`, `include/` and `lib/` folders with the typical libraries
 and modules.
 
 
+_NOTE_: Currently `liblua.a` is not added to the archive, this may easily be achieved by
+performing this shell command (after having runned `make`)
+~~~~~{.sh}
+rm libaotus.a
+ar -ru libaotus.a *.o
+ranlib libaotus.a
+~~~~~
+
 What is Built
 -------------
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This build system requires compilation in subdirectory. A minimal compilation
 mkdir build
 cd build
 {
-echo 'TOP_DIR=..'
-echo 'include $(TOP_DIR)/Makefile
+echo 'TOP_DIR = ..'
+echo 'include $(TOP_DIR)/Makefile'
 } > Makefile
 make
 ~~~~~

--- a/README.md
+++ b/README.md
@@ -43,6 +43,50 @@ By running:
 
 you get a list of available options to the waf script.
 
+### Build using Makefile
+
+Aotus also enables building the library, *libaotus.a*, using GNU `Makefile`.
+
+The build system is based on the [[smeka]] build system.  
+This build system requires compilation in subdirectory. A minimal compilation
+(defaulting to the GNU compiler suite, `gfortran`/`gcc`) is this:
+
+~~~~~{.sh}
+mkdir build
+cd build
+{
+echo 'TOP_DIR=..'
+echo 'include $(TOP_DIR)/Makefile
+} > Makefile
+make
+~~~~~
+and the resulting *libaotus.a* will be present.  
+To control the compiler flags one may create a file `setup.make` which may
+contain the regular `FC`, `FFLAGS`, `CC`, `CFLAGS`, `INCLUDES` and `LIBS`
+variables which are used to compile, and link.
+For instance to compile using only the `-g` flag:
+~~~~~{.sh}
+{
+echo FFLAGS = -g
+echo CFLAGS = -g
+} > setup.make
+~~~~~
+note that the default compiler is still the GNU suite.
+
+Aotus may be built with two variations of extended precisions. They may
+individually be turned on by setting these variables:
+~~~~~{makefile}
+EXTDOUBLE = 1 # defaults to 0 == do not build with extended double
+QUADRUPLE = 1 # defaults to 0 == do not build with quadruple double
+~~~~~
+
+To install the library together with the modules one may perform this:
+~~~~~{.sh}
+make install PREFIX=$HOME/aotus
+~~~~~
+which creates `bin/`, `include/` and `lib/` folders with the typical libraries
+and modules.
+
 
 What is Built
 -------------
@@ -141,3 +185,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ---
+
+
+[smeka]: https://github.com/zerothi/smeka

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ you get a list of available options to the waf script.
 
 Aotus also enables building the library, *libaotus.a*, using GNU `Makefile`.
 
-The build system is based on the [[smeka]] build system.  
+The build system is based on the [smeka][smeka] build system.  
 This build system requires compilation in subdirectory. A minimal compilation
 (defaulting to the GNU compiler suite, `gfortran`/`gcc`) is this:
 

--- a/smeka/Makefile.clean
+++ b/smeka/Makefile.clean
@@ -1,0 +1,30 @@
+_SMEKA_clean = 1
+
+# This smeka file has the purpose
+# of creation basic clean targets.
+
+# Remove libraries
+.PHONY: smeka-clean-lib
+smeka-clean-lib:
+	rm -f $(LIBRARIES)
+clean: smeka-clean-lib
+
+.PHONY: smeka-clean-src
+smeka-clean-src:
+	rm -f $(CPP_SOURCES)
+clean: smeka-clean-src
+
+.PHONY: smeka-clean-mod
+smeka-clean-mod:
+	rm -f $(FMOD_DIR)/*.mod $(FMOD_DIR)/*.MOD
+clean: smeka-clean-mod
+
+.PHONY: smeka-clean-obj
+smeka-clean-obj:
+	rm -f $(OBJECTS)
+clean: smeka-clean-obj
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.common
+++ b/smeka/Makefile.common
@@ -1,0 +1,53 @@
+_SMEKA_common = 1
+
+# This smeka file initializes
+# basic constants in the smeka
+
+
+# This function is doubling the addprefix addsuffix routine
+addpresuf = $(addsuffix $(2),$(addprefix $(1),$(3)))
+
+
+# We force the CC,    FC,    CXX
+#              MPICC, MPIFC, MPICXX
+# to be unitialized
+# This will enable the vendor setup using
+# a default vendor
+unexport CC
+unexport FC
+unexport CXX
+unexport MPICC
+unexport MPIFC
+unexport MPICXX
+unexport AR
+unexport RANLIB
+unexport LIBTOOL
+
+
+
+
+#######
+#######
+
+# Below are constants that does not really
+# require changes etc.
+
+# Define common variables
+_OCT_rrr = 444
+_OCT_rwrr = 644
+_OCT_rwxrxrx = 755
+_OCT_rxrxrx = 555
+
+# A newline definition used to add newlines in Makefile
+# output.
+define _NL
+
+
+endef
+
+# Typically used target to force any other target to always run
+FORCE:
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.compiler
+++ b/smeka/Makefile.compiler
@@ -1,0 +1,149 @@
+_SMEKA_compiler = 1
+
+# This smeka file creates the compiler settings.
+#
+# 1. Based on the $(VENDOR) flag the basic
+#    settings of the compiler is created.
+#    Currently the vendor(s) may be found in
+#    the vendor/ directory.
+# 2. These flags control the settings:
+#     VENDOR = gnu|intel|...
+#       select vendor compiler options
+#     OPT = debug|-1|none|0|weak|1|medium|2|hard|3
+#       select aggressiveness of the compiler
+#       flags.
+
+# We do not allow .f/.F sources
+# If a user requires other sources, they need
+# to add themselves.
+# smeka supports these files:
+_SMEKA_SUFFIXES := $(_SMEKA_SUFFIXES) .f90 .F90 .c .cc .cpp
+
+# Default compiler options
+# I am a bit split whether we should make a "default"
+# file for each vendor and pass variables to
+# a common variable space, then subsequently grabbing
+# those needed.
+
+# Default vendor setting
+VENDOR ?= gnu
+
+C_VENDOR ?= $(VENDOR)
+CXX_VENDOR ?= $(VENDOR)
+F_VENDOR ?= $(VENDOR)
+
+# Automatically decide on a single OPT flag
+# Instead of having "override" everywhere
+# we rely on a temporary variable
+OPT ?= none
+
+# First perform wrap-arounds
+ifeq ($(OPT), -1)
+  override OPT = debug
+endif
+ifeq ($(OPT), 0)
+  override OPT = none
+endif
+ifeq ($(OPT), 1)
+  override OPT = weak
+endif
+ifeq ($(OPT), 2)
+  override OPT = medium
+endif
+ifeq ($(OPT), 3)
+  override OPT = hard
+endif
+
+# All opt-flags that we process to filter out
+_FILTER_OPT_FLAGS = -Ofast -Os -O0 -O1 -O2 -O3 -O4 -O5 -fast
+
+ifneq ($(OPT),none)
+
+  # Filter out all the optimizations as they will be
+  # re-inserted below
+  CFLAGS := $(filter-out $(_FILTER_OPT_FLAGS),$(CFLAGS))
+  CXXFLAGS := $(filter-out $(_FILTER_OPT_FLAGS),$(CXXFLAGS))
+  FFLAGS := $(filter-out $(_FILTER_OPT_FLAGS),$(FFLAGS))
+
+  # Populate them
+  include $(TOP_DIR)/$(SMEKA_DIR)/vendor/$(C_VENDOR).make
+  CFLAGS += $(V_CFLAGS_$(OPT))
+
+  include $(TOP_DIR)/$(SMEKA_DIR)/vendor/$(CXX_VENDOR).make
+  CXXFLAGS += $(V_CXXFLAGS_$(OPT))
+
+  include $(TOP_DIR)/$(SMEKA_DIR)/vendor/$(F_VENDOR).make
+  FFLAGS += $(V_FFLAGS_$(OPT))
+
+else
+
+  # We simply default to include the vendor make file for fortran
+  # to retrieve the FC_MODDIR variable
+  include $(TOP_DIR)/$(SMEKA_DIR)/vendor/$(VENDOR).make
+
+endif
+
+# If requested add the PIC code flag
+ifeq ($(PIC),1)
+CFLAGS += $(V_PIC)
+CXXFLAGS += $(V_PIC)
+FFLAGS += $(V_PIC)
+endif
+
+
+# Generic compiler options
+CC ?= $(V_CC)
+CXX ?= $(V_CXX)
+FC ?= $(V_FC)
+ifdef V_CPP
+CPP ?= $(V_CPP)
+endif
+MPICC ?= $(V_MPICC)
+MPICXX ?= $(V_MPICXX)
+MPIFC ?= $(V_MPIFC)
+FC_MODDIR ?= $(V_FC_MODDIR)
+
+.PHONY: smeka-show-compiler
+.NOTPARALLEL: smeka-show-compiler
+smeka-show-compiler:
+	@echo ""
+	@echo "Used compilation options (VENDOR=$(VENDOR)):"
+	@echo "  CC       = $(CC)"
+	@echo "  CFLAGS   = $(CFLAGS)"
+	@echo "  CXX      = $(CXX)"
+	@echo "  CXXFLAGS = $(CXXFLAGS)"
+	@echo "  FC       = $(FC)"
+	@echo "  FFLAGS   = $(FFLAGS)"
+	@echo ""
+	@echo "Used MPI compilation options:"
+	@echo "  MPICC    = $(MPICC)"
+	@echo "  CFLAGS   = $(CFLAGS)"
+	@echo "  MPICXX   = $(MPICXX)"
+	@echo "  CXXFLAGS = $(CXXFLAGS)"
+	@echo "  MPIFC    = $(MPIFC)"
+	@echo "  FFLAGS   = $(FFLAGS)"
+	@echo ""
+show: smeka-show-compiler
+
+# Define the default compilation options:
+ifeq ($(SMEKA_CPP_F),0)
+%.o: %.F90
+	$(FC) -c -o $@ $(FFLAGS) $(CPPFLAGS) $(FPPFLAGS) $(INCLUDES) $<
+else
+%.o: %.F90
+	$(CPP) $(CPPFLAGS) $(FPPFLAGS) $(INCLUDES) $< > $(<:.F90=_cpp.f90)
+	$(FC) -c -o $@ $(FFLAGS) $(INCLUDES) $(<:.F90=_cpp.f90)
+endif
+%.o: %.f90
+	$(FC) -c -o $@ $(FFLAGS) $(INCLUDES) $<
+%.o: %.c
+	$(CC) -c -o $@ $(CFLAGS) $(INCLUDES) $(CPPFLAGS) $<
+%.o: %.cc
+	$(CXX) -c -o $@ $(CXXFLAGS) $(INCLUDES) $(CPPFLAGS) $<
+%.o: %.cpp
+	$(CXX) -c -o $@ $(CXXFLAGS) $(INCLUDES) $(CPPFLAGS) $<
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.default
+++ b/smeka/Makefile.default
@@ -1,0 +1,80 @@
+_SMEKA_default = 1
+
+# We simply default to include the vendor make file for fortran
+# to retrieve the FC_MODDIR variable
+
+# Default vendor setting
+VENDOR ?= gnu
+
+include $(TOP_DIR)/$(SMEKA_DIR)/vendor/$(VENDOR).make
+
+# Generic compiler options
+CC = $(V_CC)
+CXX = $(V_CXX)
+FC = $(V_FC)
+ifdef V_CPP
+CPP = $(V_CPP)
+endif
+MPICC = $(V_MPICC)
+MPICXX = $(V_MPICXX)
+MPIFC = $(V_MPIFC)
+FC_MODDIR = $(V_FC_MODDIR)
+
+ifndef SETUP
+ifneq ("$(wildcard setup.make)","")
+SETUP = setup.make
+endif
+endif
+
+
+# Sadly we MUST force set the
+# default values... :(
+# This seems mostly related to CPP
+# which gets redefined when CC is set...
+
+CFLAGS = 
+CXXFLAGS = 
+FFLAGS = 
+
+# C-preprocessor is a nightmare
+# However, these options seem to work very nicely
+#  cpp -E -x c
+#  cpp -E -P -C -nostdinc
+#  clang -E -x c
+#  clang -E -P -x c
+#  clang -E -P -xc (for clang <= 3.5)
+CPP = $(CC) -E -P -x c
+CPPFLAGS =
+# It may be suspicios that we use the C-preprocessor
+FPP = $(FC) -E -P -x c
+FPPFLAGS =
+
+# Default to not pre-process Fortran files
+SMEKA_CPP_F = 0
+
+AR = ar
+ARFLAGS = -ru
+RANLIB = ranlib
+RANLIBFLAGS =
+
+
+# Specific options for different OS
+ifeq ($(uname_S),Linux)
+endif
+ifeq ($(uname_S),Darwin)
+endif
+ifeq ($(uname_S),SunOS)
+endif
+ifeq ($(uname_S),FreeBSD)
+endif
+ifeq ($(uname_S),OpenBSD)
+endif
+ifeq ($(uname_S),NetBSD)
+endif
+ifeq ($(uname_S),Cygwin)
+endif
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.directory
+++ b/smeka/Makefile.directory
@@ -1,0 +1,55 @@
+_SMEKA_directory = 1
+
+# Determine whether the compilation
+# is being processed in a sub-directory
+# or in the main directory (. or ./)
+ifneq (,$(filter ./ .,$(TOP_DIR)))
+ # The build process is in a sub-folder
+ # and is relying on the VPATH variable
+ BUILD_MAIN_DIR = 0
+else
+ # The build process is performed in the top
+ # directory which does not necessarily
+ # depend on VPATH
+ BUILD_MAIN_DIR = 1
+endif
+
+
+# Default directories
+PREFIX ?= $(HOME)/$(PROJECT_NAME)
+# Include directory (.h)
+INC_DIR ?= $(PREFIX)/include
+# Module directory (.mod)
+FMOD_DIR ?= $(INC_DIR)
+# Executables
+BIN_DIR ?= $(PREFIX)/bin
+# Library directory (.a/.so)
+LIB_DIR ?= $(PREFIX)/lib
+# shared folder
+SHARE_DIR ?= $(PREFIX)/share
+# Manual folder (man ***)
+MAN_DIR ?= $(SHARE_DIR)/man
+# pkg-config files
+PKG_DIR ?= $(LIB_DIR)/pkgconfig
+# additional files (settings etc.)
+ETC_DIR ?= $(PREFIX)/etc
+
+
+# Print out settings from this file
+.PHONY: smeka-settings-dir
+smeka-settings-dir:
+	@echo "Directory settings:"
+	@echo "Prefix            (PREFIX) : $(PREFIX)"
+	@echo "Includes         (INC_DIR) : $(INC_DIR)"
+	@echo "Fortran modules (FMOD_DIR) : $(FMOD_DIR)"
+	@echo "Binaries         (BIN_DIR) : $(BIN_DIR)"
+	@echo "Libraries        (LIB_DIR) : $(LIB_DIR)"
+	@echo "Shared         (SHARE_DIR) : $(SHARE_DIR)"
+	@echo "Man              (MAN_DIR) : $(MAN_DIR)"
+	@echo "pkg-config       (PKG_DIR) : $(PKG_DIR)"
+	@echo "etc.             (ETC_DIR) : $(ETC_DIR)"
+settings: smeka-settings-dir
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.dist
+++ b/smeka/Makefile.dist
@@ -1,0 +1,12 @@
+_SMEKA_dist = 1
+
+# This distribution forces the creation of the
+# pre-processed sources.
+# This makes the sources available for the
+# distribution tarball.
+.PHONY: dist
+dist: $(CPP_SOURCES)
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.doc
+++ b/smeka/Makefile.doc
@@ -1,0 +1,11 @@
+_SMEKA_doc = 1
+
+# Create documentation.
+# Currently this should be user defined
+.PHONY: doc
+doc:
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.info
+++ b/smeka/Makefile.info
@@ -1,0 +1,28 @@
+_SMEKA_info = 1
+
+# Make target to inform user about
+# possible default env-vars that control the
+# smeka installation procedure
+.PHONY: smeka-info
+smeka-info:
+	@echo "Default smeka command line variables:"
+	@echo ""
+	@echo "  OPT=none|debug|weak|medium|hard"
+	@echo "    define the optimization level of the compiler"
+	@echo ""
+	@echo "  VENDOR=gnu|intel"
+	@echo "    compiler vendor, defines the standard compiler variables"
+	@echo "    (comes in C/CXX/F_VENDOR variants to control them individually)"
+	@echo ""
+	@echo "  PIC=1|0"
+	@echo "    if 1 implicitly add the position independent code flag (from vendor)"
+	@echo ""
+	@echo "  SETUP=<file>"
+	@echo "    includes <file> in the Makefile project"
+	@echo "    this may hold any custom changes to the build system"
+	@echo ""
+smeka: smeka-info
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.install
+++ b/smeka/Makefile.install
@@ -1,0 +1,52 @@
+_SMEKA_install = 1
+
+# Basic implementation of installing the different
+# libraries etc.
+
+
+.PHONY: install
+.NOTPARALLEL: install
+install: smeka-install-lib smeka-install
+
+
+.PHONY: smeka-install-lib
+.NOTPARALLEL: smeka-install-lib
+smeka-install-lib: smeka-install-init-dir
+ifneq ($(LIBRARIES),)
+	install -pm $(_OCT_rwxrxrx) -t $(LIB_DIR) $(LIBRARIES)
+endif
+
+
+.PHONY: smeka-install-init-dir
+.NOTPARALLEL: smeka-install-init-dir
+smeka-install-init-dir:
+	-mkdir -p $(INC_DIR)
+	-mkdir -p $(LIB_DIR)
+	-mkdir -p $(BIN_DIR)
+
+
+# Issuing uninstall will forcefully remove the installation directory
+.PHONY: smeka-uninstall-install
+.NOTPARALLEL: smeka-uninstall-install
+smeka-uninstall-install:
+	@echo ""
+	@echo "The directory tree:"
+	@echo "  $(PREFIX)"
+	@echo "will be deleted!"
+	@echo "You may abort the operation within 2 secs by pressing:"
+	@echo ""
+	@echo "  Ctrl+C or ^C"
+	@echo ""
+	@sleep 2
+	@rm -rf $(PREFIX)
+uninstall: smeka-uninstall-install
+
+
+# Simple way to ALWAYS do user defined stuff at the end
+.PHONY: smeka-install
+.NOTPARALLEL: smeka-install
+smeka-install:
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.library
+++ b/smeka/Makefile.library
@@ -1,0 +1,47 @@
+_SMEKA_library = 1
+
+# Libraries are so/a files.
+_SMEKA_SUFFIXES := $(_SMEKA_SUFFIXES) .so .a
+
+# Default library options
+
+# Default linker flags
+AR ?= ar
+ARFLAGS ?= -ru
+RANLIB ?= ranlib
+RANLIBFLAGS ?=
+LINK ?= $(CC)
+LINK_FLAGS ?= -shared
+
+
+.PHONY: smeka-show-lib
+.NOTPARALLEL: smeka-show-lib
+smeka-show-lib:
+	@echo ""
+	@echo "Linker (static)"
+	@echo "  AR      = $(AR)"
+	@echo "  ARFLAGS = $(ARFLAGS)"
+	@echo "  RANLIB  = $(RANLIB)"
+	@echo "  RANLIBFLAGS = $(RANLIBFLAGS)"
+	@echo "Linker (shared)"
+	@echo "  LINK    = $(LINK)"
+	@echo "  LINK_FLAGS = $(LINK_FLAGS)"
+	@echo "  LIBS    = $(LIBS)"
+	@echo "  LDFLAGS = $(LDFLAGS)"
+	@echo ""
+	@echo "  $(LINK) $(LINK_FLAGS) $(LIBS) $(LDFLAGS)"
+
+show: smeka-show-lib
+
+
+# Define the default library creation options
+%.a:
+	$(AR) $(ARFLAGS) $@ $^
+	$(RANLIB) $(RANLIBFLAGS) $@
+%.so:
+	$(LINK) $(LINK_FLAGS) -o $@ $^ $(LIBS) $(LDFLAGS)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.os
+++ b/smeka/Makefile.os
@@ -1,0 +1,18 @@
+_SMEKA_os = 1
+
+# Detect and create smeka variable for OS
+# detection.
+# These commands are heavily inspired by
+# the git makefile.
+# See: git.kernel.org/.../Makefile
+
+SMEKA_uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+SMEKA_uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+SMEKA_uname_O := $(shell sh -c 'uname -o 2>/dev/null || echo not')
+SMEKA_uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
+SMEKA_uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
+SMEKA_uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.pp
+++ b/smeka/Makefile.pp
@@ -1,0 +1,33 @@
+_SMEKA_pp = 1
+
+# This smeka file creates the preprocessor
+# settings.
+
+# Default pre-processor commands are defined in
+#    Makefile.default
+# (probably we should do a check to ensure
+#  it works)
+# Sadly there are many variations of CPP
+#   -C is needed to disregard C-comments (the operator // is a comment!?!)
+#   -nostdinc is needed to not include standard includes (which are C comments)
+#   -E only preprocess, do not try and compile
+#   -P do not add line markers
+# clang-3.5 (MacOSx): -E -xc
+# clang-3.7> (MacOSx): -E -P -x c
+# cpp(gnu): -E -P -x c -nostdinc
+
+
+.PHONY: smeka-show-pp
+.NOTPARALLEL: smeka-show-pp
+smeka-show-pp:
+	@echo "  CPP      = $(CPP)"
+	@echo "  CPPFLAGS = $(CPPFLAGS)"
+	@echo "  FPP      = $(FPP)"
+	@echo "  FPPFLAGS = $(FPPFLAGS)"
+	@echo "  INCLUDES = $(INCLUDES)"
+
+show: smeka-show-pp
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.setup
+++ b/smeka/Makefile.setup
@@ -1,0 +1,103 @@
+_SMEKA_setup = 1
+
+# This smeka file has two purposes:
+#
+# 1. Include the "setup.make" file
+#    in case it exists.
+#    This is the preferred way a user should
+#    include custom settings.
+#
+# 2. Include the $(SETUP) file.
+#    The user may specify SETUP=<> on the `make`
+#    line to (in addition to 1.) include the
+#    corresponding setup file.
+#    This setup file may also be a shortname for
+#    any of the files in the:
+#       smeka/setup/*.make
+#    folder.
+
+
+#
+# Detect whether the user requests
+# a special setup.make file from the default
+# repository.
+# If the file is found it will be included.
+# If the file is NOT found an error will be issued
+# immediately and the Make script will exit.
+
+# Check whether the local "setup.make" file
+# exists, if so, include it
+ifneq ("$(wildcard setup.make)","")
+
+include setup.make
+.PHONY: smeka-settings-setup.make
+smeka-settings-setup.make:
+	@echo "Using make settings in:"
+	@echo "  setup.make"
+settings: smeka-settings-setup.make
+
+endif
+
+
+ifdef SETUP
+ # Only process custom setup.make files
+ # via the SETUP flag.
+
+ifneq ("$(wildcard $(SETUP))","")
+ # do nothing, direct inclusion
+else ifneq ("$(wildcard setup/$(SETUP))","")
+ override SETUP = setup/$(SETUP)
+else ifneq ("$(wildcard $(SETUP).make)","")
+ override SETUP = $(SETUP).make
+else ifneq ("$(wildcard setup/$(SETUP).make)","")
+ override SETUP = setup/$(SETUP).make
+else
+ # This is a small information utility
+ $(info Could not find: $(SETUP))
+ $(info Could not find: setup/$(SETUP))
+ $(info Could not find: $(SETUP).make)
+ $(info Could not find: setup/$(SETUP).make)
+
+ # Print out the error messages for the user
+ _TMP = $(subst .make,,$(subst ./setup/,$(_NL)  ,$(wildcard ./setup/*.make)))
+ $(info Available arguments are: $(_TMP))
+ $(error Custom setup (SETUP=<>) file could not be located)
+endif
+
+# Include custom setup file
+include $(SETUP)
+
+# Figure out if the SETUP file is a relative
+# path of full path.
+ifeq ("$(wildcard ./$(SETUP))","$(SETUP)")
+SETUP_RELATIVE = 1
+else
+SETUP_RELATIVE = 0
+endif
+
+
+
+# Add print-out to target
+.PHONY: smeka-settings-custom
+smeka-settings-custom: 
+	@echo ""
+	@echo "Using custom settings:"
+	@echo "  $(SETUP)"
+	@echo ""
+settings: smeka-settings-custom
+
+endif # only check if SETUP is defined
+
+
+# Target for displaying available SETUP=<>
+.PHONY: smeka-setup-list
+smeka-setup-list:
+	@echo ""
+	$(info Available SETUP arguments are:$(_NL)$(subst .make,,$(subst ./$(SMEKA_DIR)/setup/,$(_NL)  ,$(wildcard ./$(SMEKA_DIR)/setup/*.make))))
+	@echo ""
+setup-list: smeka-setup-list
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/Makefile.smeka
+++ b/smeka/Makefile.smeka
@@ -1,0 +1,91 @@
+_SMEKA_smeka = 1
+
+# Smeka version
+SMEKA_VERSION = ace855f
+
+.PHONY: smeka-show-smeka-version
+.NOTPARALLEL: smeka-show-smeka-version
+smeka-show-smeka-version:
+	@echo ""
+	@echo "SMEKA-version = $(SMEKA_VERSION)"
+	@echo ""
+show: smeka-show-smeka-version
+
+
+# Reset the suffixes
+.SUFFIXES:
+
+# OS settings
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.os
+
+# Default variables
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.default
+
+
+# Common variables, needs pre-loading before the user
+# includes
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.common
+
+
+# Include project specific options
+# These will be pre-initialized before any user
+# settings.
+include $(TOP_DIR)/Makefile.project
+
+
+# This setup file will ALSO include the
+# user defined setups.
+# Hence from this point on any global variables
+# should be ?= assigned.
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.setup
+
+# Create the directories
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.directory
+
+
+# Add compiler specific options
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.compiler
+
+# Add preprocessor definitions
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.pp
+
+# Add library specific options
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.library
+
+# Add the installation makefile
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.install
+
+# Add the documentation makefile
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.doc
+
+# Add the distribution creation tool
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.dist
+
+# Add the clean make file
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.clean
+
+
+# There are two possibilities for post configuration
+# of the project.
+# Either in the smeka directory, or the top directory.
+# Both may be used.
+
+# Post definitions for smeka (project defined)
+-include $(TOP_DIR)/Makefile.post
+
+
+# Information settings
+# call:
+#   make smeka
+# for details
+include $(TOP_DIR)/$(SMEKA_DIR)/Makefile.info
+
+# Create the suffixes that Smeka provides
+.SUFFIXES: $(_SMEKA_SUFFIXES)
+
+
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/vendor/README
+++ b/smeka/vendor/README
@@ -1,0 +1,7 @@
+To create a new vendor compiler option you must
+copy one of the other vendor setups and
+rename it to your vendor name. Then edit the options
+in as you like.
+
+Make sure that you define all variables as those found
+in gnu.make (which we will always keep up to date).

--- a/smeka/vendor/clang.make
+++ b/smeka/vendor/clang.make
@@ -1,0 +1,53 @@
+# This contains default compiler options
+# for the GNU vendor compiler suite.
+V_VENDOR = clang
+
+# Compiler binaries
+V_CC = clang
+V_CXX = clang
+# What to do here?
+V_FC = gfortran
+V_CPP = clang -E -P -x c
+
+
+V_MPICC = mpicc
+V_MPICXX = mpic++
+V_MPIFC = mpif90
+
+# Flag for output directory of modules
+V_FC_MODDIR = -J
+
+# Flag for PIC compilation
+V_PIC = -fPIC
+
+# default compiler flags
+V_CFLAGS =
+V_CXXFLAGS =
+V_FFLAGS =
+
+# default compiler flags for debugging
+V_FLAGS_debug = -g -fbacktrace -fbounds-check -Wunused-variable -Warray-temporaries
+V_CFLAGS_debug = $(V_FLAGS_debug)
+V_CXXFLAGS_debug = $(V_FLAGS_debug)
+V_FFLAGS_debug = $(V_FLAGS_debug)
+
+# These are clang compiler options
+V_FLAGS_weak = -O1
+V_CFLAGS_weak = $(V_FLAGS_weak)
+V_CXXFLAGS_weak = $(V_FLAGS_weak)
+V_FFLAGS_weak = $(V_FLAGS_weak)
+
+V_FLAGS_medium = -O2
+V_CFLAGS_medium = $(V_FLAGS_medium)
+V_CXXFLAGS_medium = $(V_FLAGS_medium)
+V_FFLAGS_medium = $(V_FLAGS_medium)
+
+V_FLAGS_hard = -O3
+V_CFLAGS_hard = $(V_FLAGS_hard)
+V_CXXFLAGS_hard = $(V_FLAGS_hard)
+V_FFLAGS_hard = $(V_FLAGS_hard)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/vendor/gnu.make
+++ b/smeka/vendor/gnu.make
@@ -1,0 +1,51 @@
+# This contains default compiler options
+# for the GNU vendor compiler suite.
+V_VENDOR = gnu
+
+# Compiler binaries
+V_CC = gcc
+V_CXX = g++
+V_FC = gfortran
+V_CPP = cpp -E -P -x c
+
+V_MPICC = mpicc
+V_MPICXX = mpic++
+V_MPIFC = mpif90
+
+# Flag for output directory of modules
+V_FC_MODDIR = -J
+
+# Flag for PIC compilation
+V_PIC = -fPIC
+
+# default compiler flags
+V_CFLAGS =
+V_CXXFLAGS =
+V_FFLAGS =
+
+# default compiler flags for debugging
+V_FLAGS_debug = -g -fbacktrace -fbounds-check -Wunused-variable -Warray-temporaries
+V_CFLAGS_debug = $(V_FLAGS_debug)
+V_CXXFLAGS_debug = $(V_FLAGS_debug)
+V_FFLAGS_debug = $(V_FLAGS_debug)
+
+# These are gcc compiler options
+V_FLAGS_weak = -O1 -funroll-loops
+V_CFLAGS_weak = $(V_FLAGS_weak)
+V_CXXFLAGS_weak = $(V_FLAGS_weak)
+V_FFLAGS_weak = $(V_FLAGS_weak)
+
+V_FLAGS_medium = -O2 -funroll-loops -ftree-vectorize -fprefetch-loop-arrays
+V_CFLAGS_medium = $(V_FLAGS_medium)
+V_CXXFLAGS_medium = $(V_FLAGS_medium)
+V_FFLAGS_medium = $(V_FLAGS_medium)
+
+V_FLAGS_hard = -O3 -funroll-loops -ftree-vectorize -fprefetch-loop-arrays -fgraphite -fselective-scheduling
+V_CFLAGS_hard = $(V_FLAGS_hard)
+V_CXXFLAGS_hard = $(V_FLAGS_hard)
+V_FFLAGS_hard = $(V_FLAGS_hard)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/smeka/vendor/intel.make
+++ b/smeka/vendor/intel.make
@@ -1,0 +1,51 @@
+# This contains default compiler options
+# for the Intel vendor compiler suite.
+V_VENDOR = intel
+
+# Compiler binaries
+V_CC = icc
+V_CXX = icpc
+V_FC = ifort
+V_CPP = cpp -E -P -x c
+
+V_MPICC = mpicc
+V_MPICXX = mpic++
+V_MPIFC = mpif90
+
+# Flag for output directory of modules
+V_FC_MODDIR = -J
+
+# Flag for PIC compilation
+V_PIC = -fPIC
+
+# default compiler flags
+V_CFLAGS =
+V_CXXFLAGS =
+V_FFLAGS =
+
+# default compiler flags for debugging
+V_FLAGS_debug ?= -g -check bounds -traceback
+V_CFLAGS_debug = $(V_FLAGS_debug)
+V_CXXFLAGS_debug = $(V_FLAGS_debug)
+V_FFLAGS_debug = $(V_FLAGS_debug)
+
+# These are intel compiler options
+V_FLAGS_weak = -O1
+V_CFLAGS_weak = $(V_FLAGS_weak)
+V_CXXFLAGS_weak = $(V_FLAGS_weak)
+V_FFLAGS_weak = $(V_FLAGS_weak)
+
+V_FLAGS_medium = -O2 -prec-div -prec-sqrt
+V_CFLAGS_medium = $(V_FLAGS_medium)
+V_CXXFLAGS_medium = $(V_FLAGS_medium)
+V_FFLAGS_medium = $(V_FLAGS_medium)
+
+V_FLAGS_hard = -O3 -prec-div -prec-sqrt -opt-prefetch
+V_CFLAGS_hard = $(V_FLAGS_hard)
+V_CXXFLAGS_hard = $(V_FLAGS_hard)
+V_FFLAGS_hard = $(V_FLAGS_hard)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:

--- a/source/Makefile.inc
+++ b/source/Makefile.inc
@@ -1,0 +1,46 @@
+source_DIR = $(TOP_DIR)/source
+
+# Append the source directory
+VPATH := $(VPATH):$(source_DIR)
+
+# Objects in this folder
+source_OBJECTS = aot_err_module.o \
+	       aot_fun_declaration_module.o \
+	       aot_fun_module.o \
+	       aot_out_general_module.o \
+	       aot_out_module.o \
+	       aot_path_module.o \
+	       aot_references_module.o \
+	       aot_table_module.o \
+	       aot_table_ops_module.o \
+	       aot_top_module.o \
+	       aotus_module.o \
+	       aot_vector_module.o
+source_SOURCES := $(patsubst %.o, %.f90, $(source_OBJECTS))
+
+# Add dependency for the LuaFortran objects
+$(source_OBJECTS): $(LuaF_OBJECTS)
+
+# Add to the global variables
+SOURCES += $(source_SOURCES)
+OBJECTS += $(source_OBJECTS)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:
+
+# Automatic creation of the dependencies may be achieved through:
+#   sfmakedepend --depend=obj --modext=o --file=Makefile.inc *.f90
+
+# DO NOT DELETE THIS LINE - used by make depend
+aot_fun_module.o: aot_fun_declaration_module.o aot_references_module.o
+aot_fun_module.o: aot_table_module.o aot_top_module.o
+aot_out_module.o: aot_out_general_module.o
+aot_path_module.o: aot_fun_module.o aot_table_module.o aotus_module.o
+aot_references_module.o: aot_table_ops_module.o
+aot_table_module.o: aot_err_module.o aot_table_ops_module.o aot_top_module.o
+aot_table_ops_module.o: aot_top_module.o
+aot_top_module.o: aot_err_module.o
+aot_vector_module.o: aot_table_ops_module.o aot_top_module.o
+aotus_module.o: aot_table_module.o aot_top_module.o aot_vector_module.o

--- a/source/extdouble/Makefile.inc
+++ b/source/extdouble/Makefile.inc
@@ -1,0 +1,44 @@
+extdouble_DIR = $(TOP_DIR)/source/extdouble
+
+# Append the source/extdouble directory
+VPATH := $(VPATH):$(extdouble_DIR)
+
+# Objects in this folder
+ifneq ($(EXTDOUBLE),0)
+extdouble_OBJECTS = \
+	       aot_extdouble_fun_module.o \
+	       aot_extdouble_out_module.o \
+	       aot_extdouble_table_module.o \
+	       aot_extdouble_top_module.o \
+	       aot_extdouble_vector_module.o
+else
+extdouble_OBJECTS = \
+	       dummy_extdouble_fun_module.o \
+	       dummy_extdouble_out_module.o \
+	       dummy_extdouble_table_module.o \
+	       dummy_extdouble_top_module.o \
+	       dummy_extdouble_vector_module.o
+endif
+extdouble_SOURCES := $(patsubst %.o, %.f90, $(extdouble_OBJECTS))
+
+# Add dependency for the LuaFortran objects
+$(extdouble_OBJECTS): $(LuaF_OBJECTS)
+$(source_OBJECTS): $(extdouble_OBJECTS)
+
+# Add to the global variables
+SOURCES += $(extdouble_SOURCES)
+OBJECTS += $(extdouble_OBJECTS)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:
+
+# Automatic creation of the dependencies may be achieved through:
+#   sfmakedepend --depend=obj --modext=o --file=Makefile.inc *.f90
+
+# DO NOT DELETE THIS LINE - used by make depend
+aot_extdouble_fun_module.o: aot_extdouble_top_module.o
+aot_extdouble_out_module.o: aot_extdouble_top_module.o
+aot_extdouble_table_module.o: aot_extdouble_top_module.o
+aot_extdouble_vector_module.o: aot_extdouble_top_module.o

--- a/source/quadruple/Makefile.inc
+++ b/source/quadruple/Makefile.inc
@@ -1,0 +1,45 @@
+quadruple_DIR = $(TOP_DIR)/source/quadruple
+
+# Append the source/quadruple directory
+VPATH := $(VPATH):$(quadruple_DIR)
+
+# Objects in this folder
+ifneq ($(QUADRUPLE),0)
+quadruple_OBJECTS = \
+	       aot_quadruple_fun_module.o \
+	       aot_quadruple_out_module.o \
+	       aot_quadruple_table_module.o \
+	       aot_quadruple_top_module.o \
+	       aot_quadruple_vector_module.o
+else
+quadruple_OBJECTS = \
+	       dummy_quadruple_fun_module.o \
+	       dummy_quadruple_out_module.o \
+	       dummy_quadruple_table_module.o \
+	       dummy_quadruple_top_module.o \
+	       dummy_quadruple_vector_module.o
+endif
+quadruple_SOURCES := $(patsubst %.o, %.f90, $(quadruple_OBJECTS))
+
+# Add dependency for the LuaFortran objects
+$(quadruple_OBJECTS): $(LuaF_OBJECTS)
+$(source_OBJECTS): $(quadruple_OBJECTS)
+
+# Add to the global variables
+SOURCES += $(quadruple_SOURCES)
+OBJECTS += $(quadruple_OBJECTS)
+
+
+# Local Variables:
+#  mode: makefile-gmake
+# End:
+
+
+# Automatic creation of the dependencies may be achieved through:
+#   sfmakedepend --depend=obj --modext=o --file=Makefile.inc aot*.f90
+
+# DO NOT DELETE THIS LINE - used by make depend
+aot_quadruple_fun_module.o: aot_quadruple_top_module.o
+aot_quadruple_out_module.o: aot_quadruple_top_module.o
+aot_quadruple_table_module.o: aot_quadruple_top_module.o
+aot_quadruple_vector_module.o: aot_quadruple_top_module.o


### PR DESCRIPTION
Now aotus may be built entirely using Make.

It uses the Smeka build system which is really just a lot of wrap-up targets made to ease the creation of installation targets, and other targets in a build.

Currently, I just need to figure out how to add the liblua.a members to libaotus in a clean way.

(also note that one may easily build both a shared and a static library:
```
make # produces static
make SHARED=1 # produces static and shared
make SHARED=1 STATIC=0 # produces shared
```
)