### PR TITLE
enh: ensured no reallocation checks are performed

### DIFF
--- a/source/aot_vector_module.f90
+++ b/source/aot_vector_module.f90
@@ -822,7 +822,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,
@@ -923,7 +923,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,
@@ -1023,7 +1023,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,
@@ -1123,7 +1123,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,
@@ -1223,7 +1223,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,
@@ -1323,7 +1323,7 @@ contains
           if (present(default)) then
             allocate(val(def_len))
             allocate(errCode(def_len))
-            val = default
+            val(:) = default
             ErrCode = ibSet(0, aoterr_NonExistent)
           else
             ! No vector definition in the Lua script and no default provided,

--- a/source/extdouble/Makefile.inc
+++ b/source/extdouble/Makefile.inc
@@ -11,6 +11,12 @@ extdouble_OBJECTS = \
 	       aot_extdouble_table_module.o \
 	       aot_extdouble_top_module.o \
 	       aot_extdouble_vector_module.o
+aot_top_module.o: aot_extdouble_top_module.o
+aot_out_module.o: aot_extdouble_out_module.o
+aot_fun_module.o: aot_extdouble_fun_module.o
+aot_table_module.o: aot_extdouble_table_module.o
+aot_vector_module.o: aot_extdouble_vector_module.o
+aot_extdouble_top_module.o: aot_err_module.o
 else
 extdouble_OBJECTS = \
 	       dummy_extdouble_fun_module.o \
@@ -18,12 +24,16 @@ extdouble_OBJECTS = \
 	       dummy_extdouble_table_module.o \
 	       dummy_extdouble_top_module.o \
 	       dummy_extdouble_vector_module.o
+aot_top_module.o: dummy_extdouble_top_module.o
+aot_out_module.o: dummy_extdouble_out_module.o
+aot_fun_module.o: dummy_extdouble_fun_module.o
+aot_table_module.o: dummy_extdouble_table_module.o
+aot_vector_module.o: dummy_extdouble_vector_module.o
 endif
 extdouble_SOURCES := $(patsubst %.o, %.f90, $(extdouble_OBJECTS))
 
 # Add dependency for the LuaFortran objects
 $(extdouble_OBJECTS): $(LuaF_OBJECTS)
-$(source_OBJECTS): $(extdouble_OBJECTS)
 
 # Add to the global variables
 SOURCES += $(extdouble_SOURCES)

--- a/source/extdouble/aot_extdouble_table_module.f90
+++ b/source/extdouble/aot_extdouble_table_module.f90
@@ -213,7 +213,7 @@ contains
 
     nVals = size(val)
     allocate(locVal(nVals))
-    locVal = real(val, kind=double_k)
+    locVal(:) = real(val, kind=double_k)
     call flu_createtable(L, nVals, 0)
     thandle = flu_gettop(L)
     tab = thandle

--- a/source/extdouble/aot_extdouble_vector_module.f90
+++ b/source/extdouble/aot_extdouble_vector_module.f90
@@ -260,7 +260,7 @@ contains
       if (present(default)) then
         allocate(val(def_len))
         allocate(errCode(vect_len))
-        val = default
+        val(:) = default
         ErrCode = ibSet(0, aoterr_NonExistent)
       else
         ! No vector definition in the Lua script and no default provided,

--- a/source/quadruple/Makefile.inc
+++ b/source/quadruple/Makefile.inc
@@ -11,6 +11,12 @@ quadruple_OBJECTS = \
 	       aot_quadruple_table_module.o \
 	       aot_quadruple_top_module.o \
 	       aot_quadruple_vector_module.o
+aot_top_module.o: aot_quadruple_top_module.o
+aot_out_module.o: aot_quadruple_out_module.o
+aot_fun_module.o: aot_quadruple_fun_module.o
+aot_table_module.o: aot_quadruple_table_module.o
+aot_vector_module.o: aot_quadruple_vector_module.o
+aot_quadruple_top_module.o: aot_err_module.o
 else
 quadruple_OBJECTS = \
 	       dummy_quadruple_fun_module.o \
@@ -18,12 +24,16 @@ quadruple_OBJECTS = \
 	       dummy_quadruple_table_module.o \
 	       dummy_quadruple_top_module.o \
 	       dummy_quadruple_vector_module.o
+aot_top_module.o: dummy_quadruple_top_module.o
+aot_out_module.o: dummy_quadruple_out_module.o
+aot_fun_module.o: dummy_quadruple_fun_module.o
+aot_table_module.o: dummy_quadruple_table_module.o
+aot_vector_module.o: dummy_quadruple_vector_module.o
 endif
 quadruple_SOURCES := $(patsubst %.o, %.f90, $(quadruple_OBJECTS))
 
 # Add dependency for the LuaFortran objects
 $(quadruple_OBJECTS): $(LuaF_OBJECTS)
-$(source_OBJECTS): $(quadruple_OBJECTS)
 
 # Add to the global variables
 SOURCES += $(quadruple_SOURCES)

--- a/source/quadruple/aot_quadruple_table_module.f90
+++ b/source/quadruple/aot_quadruple_table_module.f90
@@ -213,7 +213,7 @@ contains
 
     nVals = size(val)
     allocate(locVal(nVals))
-    locVal = real(val, kind=double_k)
+    locVal(:) = real(val, kind=double_k)
     call flu_createtable(L, nVals, 0)
     thandle = flu_gettop(L)
     tab = thandle

--- a/source/quadruple/aot_quadruple_vector_module.f90
+++ b/source/quadruple/aot_quadruple_vector_module.f90
@@ -260,7 +260,7 @@ contains
       if (present(default)) then
         allocate(val(def_len))
         allocate(errCode(vect_len))
-        val = default
+        val(:) = default
         ErrCode = ibSet(0, aoterr_NonExistent)
       else
         ! No vector definition in the Lua script and no default provided,


### PR DESCRIPTION
When assigning to allocatable variables, the f03 standard allows
for reallocation if the dimensions does not fit. This is an
extra level of overhead.
The simple fix is to use array assignment instead and then no
reallocation check is performed.

Signed-off-by: Nick Papior <nickpapior@gmail.com>