### PR TITLE
Remove deprecated files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-build:
-  stage: build
-  script:
-    - ./waf configure debug build

--- a/.hgtags
+++ b/.hgtags
@@ -1,1 +1,0 @@
-bfb6dafab79adb08968c0846638953421549ef67 v0_interface


### PR DESCRIPTION
The hidden files `.hgtags` and `.gitlab-ci.yml` are not needed anymore and can be removed.