### PR TITLE
Add Compiler flags for flang

### DIFF
--- a/fortran_compiler.py
+++ b/fortran_compiler.py
@@ -33,6 +33,7 @@
 ### by the waflib/extras/fc_* tools.
 ### * BGXLF (XLF on BlueGene)
 ### * CRAY (Cray Compiler)
+### * FLANG (LLVM Compiler)
 ### * GFORTRAN (Gnu Fortran Compiler from the GCC)
 ### * IFORT (Intel Fortran Compiler)
 ### * NAG (NAG Fortran Compiler)
@@ -82,6 +83,19 @@ fcopts['GFORTRAN', 'pre'] = ['-cpp']
 fcopts['GFORTRAN', 'profile'] = ['-pg']
 fcopts['GFORTRAN', 'fixform'] = ['-ffixed-form']
 fcopts['GFORTRAN', 'freeform'] = ['-ffree-form']
+
+fcopts['FLANG', 'warn'] = ['-Wall' ]
+fcopts['FLANG', 'w2e'] = ['-Werror']
+fcopts['FLANG', 'standard'] = ['-std=f2008']
+fcopts['FLANG', 'double'] = ['-fdefault-real-8']
+fcopts['FLANG', 'debug'] = ['-O0', '-g']
+fcopts['FLANG', 'optimize'] = ['-O3', '-march=native']
+fcopts['FLANG', 'openmp'] = ['-fopenmp']
+fcopts['FLANG', 'noomp'] = []
+fcopts['FLANG', 'pre'] = ['-cpp']
+fcopts['FLANG', 'profile'] = ['-pg']
+fcopts['FLANG', 'fixform'] = ['-ffixed-form']
+fcopts['FLANG', 'freeform'] = ['-ffree-form']
 
 fcopts['IFORT', 'warn'] = '-warn all,noexternal'.split()
 fcopts['IFORT', 'w2e'] = '-warn stderrors'.split()


### PR DESCRIPTION
This adds a section for  the flags to use with flang, though the waf executable does not support this yet. It is available in [6595748b9183ec9f5fb0dec491021767576e4eae](https://gitlab.com/ita1024/waf/-/commit/6595748b9183ec9f5fb0dec491021767576e4eae), but there is no official release of waf with that change yet.